### PR TITLE
Ensure we always configure a body

### DIFF
--- a/lib/customerio-rails/mail.rb
+++ b/lib/customerio-rails/mail.rb
@@ -29,7 +29,14 @@ module CustomerioRails
           else
             params[:body] = mail.html_part.body.to_s if mail.html_part
             params[:body_plain] = mail.text_part.body.to_s if mail.text_part
-            params[mail.text? ? :body_plain : :body] = mail.body.to_s if !mail.html_part && !mail.text_part
+            if params[:body].blank?
+              if mail.text?
+                params[:body] = ''
+                params[:body_plain] = mail.body.to_s if params[:body_plain].blank?
+              else
+                params[:body] = mail.body.to_s
+              end
+            end
           end
           request = ::Customerio::SendEmailRequest.new(params.compact)
           mail.attachments.each do |attachment|

--- a/lib/customerio-rails/version.rb
+++ b/lib/customerio-rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CustomerioRails
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -19,7 +19,7 @@ describe 'Delivering messages with customerio-rails' do
   context 'when delivering a simple message' do
     let(:expected_body) do
       { 'to' => 'sheldon@bigbangtheory.com', 'from' => 'leonard@bigbangtheory.com', 'subject' => 'hello',
-        'body_plain' => "hello\n", 'headers' => {}, 'identifiers' => { 'email' => 'sheldon@bigbangtheory.com' }, 'attachments' => {} }
+        'body' => '', 'body_plain' => "hello\n", 'headers' => {}, 'identifiers' => { 'email' => 'sheldon@bigbangtheory.com' }, 'attachments' => {} }
     end
 
     let(:message) { TestMailer.simple_message }
@@ -65,7 +65,7 @@ describe 'Delivering messages with customerio-rails' do
   context 'when delivering with a nice from address' do
     let(:expected_body) do
       {"to" => "sheldon@bigbangtheory.com", "from" => "Leonard Hofstadter <leonard@bigbangtheory.com>",
-        "subject" => "hello", "headers" => {}, "identifiers" => {"email" => "sheldon@bigbangtheory.com"}, "body_plain" => "hello", "attachments" => {}}
+        "subject" => "hello", "headers" => {}, "identifiers" => {"email" => "sheldon@bigbangtheory.com"}, "body" => "", "body_plain" => "hello", "attachments" => {}}
     end
 
     it do
@@ -89,7 +89,7 @@ describe 'Delivering messages with customerio-rails' do
   context 'when delivering a single part message' do
     let(:expected_body) do
       { 'to' => 'sheldon@bigbangtheory.com', 'from' => 'leonard@bigbangtheory.com',
-        'subject' => 'Your invitation to join Mixlr.', "body_plain" => "hello\n", 'headers' => {}, 'identifiers' => { 'email' => 'sheldon@bigbangtheory.com' }, 'attachments' => {} }
+        'subject' => 'Your invitation to join Mixlr.', "body" => "", "body_plain" => "hello\n", 'headers' => {}, 'identifiers' => { 'email' => 'sheldon@bigbangtheory.com' }, 'attachments' => {} }
     end
 
     it do


### PR DESCRIPTION
Let's try with an empty `body`.