### PR TITLE
Suppport `tracked` option

### DIFF
--- a/lib/customerio-rails/mail.rb
+++ b/lib/customerio-rails/mail.rb
@@ -21,8 +21,9 @@ module CustomerioRails
             reply_to: mail.reply_to,
             bcc: mail.bcc,
             headers: mail.headers,
-            identifiers: { email: to } 
+            identifiers: { email: to }
           }
+          params[:tracked] = mail[:tracked].unparsed_value == true unless mail[:tracked].nil?
           if mail[:transactional_message_id]
             params[:transactional_message_id] = mail[:transactional_message_id].unparsed_value
             params[:message_data] = mail[:message_data]&.unparsed_value || {}

--- a/lib/customerio-rails/version.rb
+++ b/lib/customerio-rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CustomerioRails
-  VERSION = '0.2.2'
+  VERSION = '0.3.0'
 end

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -135,4 +135,31 @@ describe 'Delivering messages with customerio-rails' do
       message.deliver!
     end
   end
+
+  context 'when delivering a message without tracking' do
+    let(:message) { TestMailer.message_without_tracked }
+
+    let(:expected_body) do
+      { "to" => "sheldon@bigbangtheory.com", "from" => "leonard@bigbangtheory.com", "subject" => "Message without tracking.", "headers" => {},
+        "identifiers" => {"email" => "sheldon@bigbangtheory.com"}, "tracked" => false, "body" => "", "body_plain" => "whatever", "attachments" => {} }
+    end
+
+    it do
+      message.deliver!
+    end
+  end
+
+
+  context 'when delivering a message with tracking' do
+    let(:message) { TestMailer.message_with_tracked }
+
+    let(:expected_body) do
+      { "to" => "sheldon@bigbangtheory.com", "from" => "leonard@bigbangtheory.com", "subject" => "Message without tracking.", "headers" => {},
+        "identifiers" => {"email" => "sheldon@bigbangtheory.com"}, "tracked" => true, "body" => "", "body_plain" => "whatever", "attachments" => {} }
+    end
+
+    it do
+      message.deliver!
+    end
+  end
 end

--- a/spec/fixtures/models/test_mailer.rb
+++ b/spec/fixtures/models/test_mailer.rb
@@ -41,6 +41,14 @@ class TestMailer < ActionMailer::Base
     mail(subject: 'Message with template.', transactional_message_id: '123', message_data: { foo: 'bar' })
   end
 
+  def message_with_tracked
+    mail(subject: 'Message without tracking.', tracked: true, body: 'whatever')
+  end
+
+  def message_without_tracked
+    mail(subject: 'Message without tracking.', tracked: false, body: 'whatever')
+  end
+
   protected
 
   def image_file


### PR DESCRIPTION
So the client can decide whether an email is tracked or not